### PR TITLE
Allow CODEOWNERS declare rules with no owners

### DIFF
--- a/cmd/codeowners/main.go
+++ b/cmd/codeowners/main.go
@@ -86,7 +86,7 @@ func printFileOwners(ruleset codeowners.Ruleset, path string, ownerFilters []str
 		return err
 	}
 	// If we didn't get a match, the file is unowned
-	if rule == nil {
+	if rule == nil || rule.Owners == nil {
 		// Don't show unowned files if we're filtering by owner
 		if len(ownerFilters) == 0 {
 			fmt.Printf("%-70s  (unowned)\n", path)

--- a/parse.go
+++ b/parse.go
@@ -117,8 +117,15 @@ func parseRule(ruleStr string) (Rule, error) {
 	// if the line didn't end with a separator (whitespace)
 	switch state {
 	case statePattern:
-		// We should have at least one owner as well
-		return r, fmt.Errorf("unexpected end of rule")
+		if buf.Len() == 0 { // We should have non-empty pattern
+			return r, fmt.Errorf("unexpected end of rule")
+		}
+
+		pattern, err := newPattern(buf.String())
+		if err != nil {
+			return r, err
+		}
+		r.pattern = pattern
 
 	case stateOwners:
 		// If there's an owner left in the buffer, don't leave it behind
@@ -130,11 +137,6 @@ func parseRule(ruleStr string) (Rule, error) {
 			}
 			r.Owners = append(r.Owners, owner)
 		}
-	}
-
-	// All rules need at least one owner
-	if len(r.Owners) == 0 {
-		return r, fmt.Errorf("unexpected end of rule")
 	}
 
 	return r, nil

--- a/parse_test.go
+++ b/parse_test.go
@@ -75,16 +75,38 @@ func TestParseRule(t *testing.T) {
 				Comment: "some comment",
 			},
 		},
+		{
+			name: "pattern with no owners",
+			rule: "pattern",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "pattern"),
+				Owners:  nil,
+				Comment: "",
+			},
+		},
+		{
+			name: "pattern with no owners and comment",
+			rule: "pattern # but no more",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "pattern"),
+				Owners:  nil,
+				Comment: "but no more",
+			},
+		},
+		{
+			name: "pattern with no owners with whitespace",
+			rule: "pattern ",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "pattern"),
+				Owners:  nil,
+				Comment: "",
+			},
+		},
 
 		// Error cases
 		{
 			name: "empty rule",
 			rule: "",
-			err:  "unexpected end of rule",
-		},
-		{
-			name: "no owners",
-			rule: "pattern # but no more",
 			err:  "unexpected end of rule",
 		},
 		{


### PR DESCRIPTION
As described in documentation https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax